### PR TITLE
clang-format: update to 14

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -1,7 +1,7 @@
 -   id: clang-format
     name: clang-format
     description: Format files with ClangFormat.
-    entry: clang-format-10 -i
+    entry: clang-format-14 -i
     language: system
     files: \.(c|cc|cxx|cpp|frag|glsl|h|hpp|hxx|ih|ispc|ipp|java|js|m|mm|proto|vert)$
     args: ['-fallback-style=none']


### PR DESCRIPTION
needed for Ubuntu 22.04 where `clang-format-10` doesn't exist anymore